### PR TITLE
Update ybcodes.csv

### DIFF
--- a/data/ybcodes.csv
+++ b/data/ybcodes.csv
@@ -597,6 +597,7 @@ onetwo2019
 orcv2011return
 orcv2012return
 osaka2013
+ostar2013
 ottocusmano
 otyr2014
 otyr2016
@@ -654,6 +655,8 @@ rajamuda2019_5
 rajamuda2019
 rallye_2019
 raven
+rbandi2014
+rbi2018
 rbni2018
 rdsas2012
 rdsas2013


### PR DESCRIPTION
add a few more missing races. Both RWYC and RORC run Round Britain and Ireland races every four years, on the same years, and they are maddeningly inconsistent about the ybcodes they use. The RWYC is doublehanded with stops, RORC's is nonstop fully crewed (dh allowed).